### PR TITLE
Make sure to properly escape value strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ cloudSearchDomain.search({
 });
 ```
 
-**NOTE:** Because of the CloudSearch limitations query builder removes the double quotes from the search parameters.
+**NOTE:** Because of the CloudSearch limitations, query builder removes double quotes from the search parameters.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ cloudSearchDomain.search({
 });
 ```
 
+    ###Important
+    Because of the CloudSearch limitations query builder removes the double quotes from the search parameters.
+
 ## Contributing
 
 Contributions to cloudsearch-query-builder are very welcome! Please make sure to follow the [Contribution Guidelines](.github/CONTRIBUTING.MD). Areas that you could help out with include, but are not limited to:

--- a/README.md
+++ b/README.md
@@ -67,8 +67,7 @@ cloudSearchDomain.search({
 });
 ```
 
-    ###Important
-    Because of the CloudSearch limitations query builder removes the double quotes from the search parameters.
+**NOTE:** Because of the CloudSearch limitations query builder removes the double quotes from the search parameters.
 
 ## Contributing
 

--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 'use strict';
 
 function quote(value) {
-    value = value.replace(/[\\']/g, '\\$&').replace(/["]/g, '');
     if (typeof value === 'string') {
+        value = value.replace(/[\\']/g, '\\$&').replace(/["]/g, '');
         return `'${value}'`;
     }
 

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ function quote(value) {
         // Escape all backslashes and single quotes (assume the parameter
         // was completely unescaped, so escape all). Also remove double
         // quotes as CS is fussy about them in values in structured queries
-        value = value.replace(/[\\']/g, '\\$&').replace('"', '');
+        value = value.replace(/[\\']/g, '\\$&').replace(/"/g, '');
         return `'${value}'`;
     }
 

--- a/index.js
+++ b/index.js
@@ -2,7 +2,10 @@
 
 function quote(value) {
     if (typeof value === 'string') {
-        value = value.replace(/[\\']/g, '\\$&').replace(/["]/g, '');
+        // Escape all backslashes and single quotes (assume the parameter
+        // was completely unescaped, so escape all). Also remove double
+        // quotes as CS is fussy about them in values in structured queries
+        value = value.replace(/[\\']/g, '\\$&').replace('"', '');
         return `'${value}'`;
     }
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 function quote(value) {
+    value = value.replace(/[\\']/g, '\\$&').replace(/["]/g, '');
     if (typeof value === 'string') {
         return `'${value}'`;
     }


### PR DESCRIPTION
- [X] Issue exists - N/A (Internally tracked)
- [X] Linter passes (`npm run lint`)
- [X] Tests pass (`npm run test`)
- [X] CircleCI build is green
- [X] Documentation is up to date (README + comments)

Brief overview of changes:
- Fixing a problem where having single quotes or backslashes in any of the string values caused problems with CloudSearch.
- Fixing a problem where CloudSearch was very picky about double quotes in those same strings, current solution (the only one that seemed to work) is to just strip all double quotes from the string.

![Interesting](http://i.giphy.com/KKtAZiNVEeU8.gif)